### PR TITLE
Mining Fatigue Trap

### DIFF
--- a/api/src/main/java/io/github/pronze/sba/MessageKeys.java
+++ b/api/src/main/java/io/github/pronze/sba/MessageKeys.java
@@ -90,9 +90,12 @@ public class MessageKeys {
     public static final String[] VICTORY_TITLE = {"victory-title"};
     public static final String[] ROTATING_GENERATOR_FORMAT = {"floating-generator", "holo-text"};
     public static final String[] ROTATING_GENERATOR_FULL_TEXT_FORMAT = {"floating-generator", "full-text"};
-    public static final String[] TEAM_TRAP_TRIGGERED_MESSAGE = {"trap-triggered", "message"};
-    public static final String[] TEAM_TRAP_TRIGGERED_TITLE = {"trap-triggered", "title"};
-    public static final String[] TEAM_TRAP_TRIGGERED_SUBTITLE = {"trap-triggered", "sub-title"};
+    public static final String[] TEAM_BLIND_TRAP_TRIGGERED_MESSAGE = {"blind-trap-triggered", "message"};
+    public static final String[] TEAM_BLIND_TRAP_TRIGGERED_TITLE = {"blind-trap-triggered", "title"};
+    public static final String[] TEAM_BLIND_TRAP_TRIGGERED_SUBTITLE = {"blind-trap-triggered", "sub-title"};
+    public static final String[] TEAM_MINER_TRAP_TRIGGERED_MESSAGE = {"miner-trap-triggered", "message"};
+    public static final String[] TEAM_MINER_TRAP_TRIGGERED_TITLE = {"miner-trap-triggered", "title"};
+    public static final String[] TEAM_MINER_TRAP_TRIGGERED_SUBTITLE = {"miner-trap-triggered", "sub-title"};
     public static final String[] GENERATOR_UPGRADE_MESSAGE = {"generator-upgrade"};
     public static final String[] RESPAWN_COUNTDOWN_TITLE = {"respawn-title"};
     public static final String[] RESPAWN_COUNTDOWN_SUBTITLE = {"respawn-subtitle"};
@@ -103,6 +106,7 @@ public class MessageKeys {
     public static final String[] GREATEST_ENCHANTMENT = {"greatest-enchantment"};
     public static final String[] WAIT_FOR_TRAP = {"wait-trap"};
     public static final String[] BLINDNESS_TRAP_PURCHASED_TITLE = {"blindness-trap-purchased-title"};
+    public static final String[] MINER_TRAP_PURCHASED_TITLE = {"miner-trap-purchased-title"};
     public static final String[] PURCHASED_HEAL_POOL_MESSAGE = {"purchase-heal-pool"};
     public static final String[] UPGRADE_TEAM_PROTECTION = {"upgrade-team-protection"};
     public static final String[] UGPRADE_TEAM_SHARPNESS = {"upgrade-team-sharpness"};

--- a/api/src/main/java/io/github/pronze/sba/data/GameTeamData.java
+++ b/api/src/main/java/io/github/pronze/sba/data/GameTeamData.java
@@ -38,9 +38,14 @@ public class GameTeamData {
     private boolean purchasedPool;
 
     /**
-     * A boolean representing whether the team has purchased the Trap upgrade from the Upgrades store.
+     * A boolean representing whether the team has purchased the Blind Trap upgrade from the Upgrades store.
      */
-    private boolean purchasedTrap;
+    private boolean purchasedBlindTrap;
+
+    /**
+     * A boolean representing whether the team has purchased the Miner Trap upgrade from the Upgrades store.
+     */
+    private boolean purchasedMinerTrap;
 
     /**
      * A boolean representing whether the team has purchased the Dragon upgrade from the Upgrades store.

--- a/api/src/main/java/io/github/pronze/sba/game/IGameStorage.java
+++ b/api/src/main/java/io/github/pronze/sba/game/IGameStorage.java
@@ -63,9 +63,16 @@ public interface IGameStorage {
     /**
      * Sets whether the trap has been enabled for the specified team.
      * @param team the team instance to set
-     * @param isTrapEnabled the trap boolean to be set
+     * @param isBlindTrapEnabled the trap boolean to be set
      */
-    void setPurchasedTrap(@NotNull RunningTeam team, boolean isTrapEnabled);
+    void setPurchasedBlindTrap(@NotNull RunningTeam team, boolean isBlindTrapEnabled);
+
+    /**
+     * Sets whether the trap has been enabled for the specified team.
+     * @param team the team instance to set
+     * @param isMinerTrapEnabled the trap boolean to be set
+     */
+    void setPurchasedMinerTrap(@NotNull RunningTeam team, boolean isMinerTrapEnabled);
 
     /**
      * Sets whether the pool has been enabled for the specified team.
@@ -82,10 +89,16 @@ public interface IGameStorage {
     void setPurchasedDragons(@NotNull RunningTeam team, boolean isDragonsEnabled);
 
     /**
-     * Returns a boolean if the traps are enabled for any teams in the game.
+     * Returns a boolean if the blindness trap are enabled for any teams in the game.
      * @return true if traps are enabled for any teams in the game, false otherwise
      */
-    boolean areTrapsEnabled();
+    boolean areBlindTrapEnabled();
+
+    /**
+     * Returns a boolean if the miner trap are enabled for any teams in the game.
+     * @return true if traps are enabled for any teams in the game, false otherwise
+     */
+    boolean areMinerTrapEnabled();
 
     /**
      * Returns a boolean if the pools are enabled for any teams in the game.
@@ -100,11 +113,18 @@ public interface IGameStorage {
     boolean areDragonsEnabled();
 
     /**
+     * Returns a boolean if the blindness trap are enabled for the specified team.
+     * @param team the team instance to query
+     * @return true if traps are enabled for the specified team, false otherwise
+     */
+    boolean areBlindTrapEnabled(@NotNull RunningTeam team);
+
+    /**
      * Returns a boolean if the traps are enabled for the specified team.
      * @param team the team instance to query
      * @return true if traps are enabled for the specified team, false otherwise
      */
-    boolean areTrapsEnabled(@NotNull RunningTeam team);
+    boolean areMinerTrapEnabled(@NotNull RunningTeam team);
 
     /**
      * Returns a boolean if the pool are enabled for the specified team.

--- a/plugin/src/main/java/io/github/pronze/sba/game/GameStorage.java
+++ b/plugin/src/main/java/io/github/pronze/sba/game/GameStorage.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 public class GameStorage implements IGameStorage {
     private final Map<RunningTeam, GameTeamData> teamDataMap = new HashMap<>();
+    private RunningTeam team;
 
     public GameStorage(Game game) {
         game.getRunningTeams().forEach(team -> teamDataMap.put(team, GameTeamData.of(team)));
@@ -74,11 +75,19 @@ public class GameStorage implements IGameStorage {
     }
 
     @Override
-    public void setPurchasedTrap(@NotNull RunningTeam team, boolean isTrapEnabled) {
+    public void setPurchasedBlindTrap(@NotNull RunningTeam team, boolean isBlindTrapEnabled) {
         if (!teamDataMap.containsKey(team)) {
             throw new UnsupportedOperationException("Team: " + team.getName() + " has not been registered yet!");
         }
-        teamDataMap.get(team).setPurchasedTrap(isTrapEnabled);
+        teamDataMap.get(team).setPurchasedBlindTrap(isBlindTrapEnabled);
+    }
+
+    @Override
+    public void setPurchasedMinerTrap(@NotNull RunningTeam team, boolean isMinerTrapEnabled) {
+        if (!teamDataMap.containsKey(team)) {
+            throw new UnsupportedOperationException("Team: " + team.getName() + " has not been registered yet!");
+        }
+        teamDataMap.get(team).setPurchasedBlindTrap(isMinerTrapEnabled);
     }
 
     @Override
@@ -98,11 +107,19 @@ public class GameStorage implements IGameStorage {
     }
 
     @Override
-    public boolean areTrapsEnabled(@NotNull RunningTeam team) {
+    public boolean areBlindTrapEnabled(@NotNull RunningTeam team) {
         if (!teamDataMap.containsKey(team)) {
             throw new UnsupportedOperationException("Team: " + team.getName() + " has not been registered yet!");
         }
-        return teamDataMap.get(team).isPurchasedTrap();
+        return teamDataMap.get(team).isPurchasedBlindTrap();
+    }
+
+    @Override
+    public boolean areMinerTrapEnabled(@NotNull RunningTeam team) {
+        if (!teamDataMap.containsKey(team)) {
+            throw new UnsupportedOperationException("Team: " + team.getName() + " has not been registered yet!");
+        }
+        return teamDataMap.get(team).isPurchasedMinerTrap();
     }
 
     @Override
@@ -130,11 +147,19 @@ public class GameStorage implements IGameStorage {
     }
 
     @Override
-    public boolean areTrapsEnabled() {
+    public boolean areBlindTrapEnabled() {
         return teamDataMap
                 .values()
                 .stream()
-                .anyMatch(GameTeamData::isPurchasedTrap);
+                .anyMatch(GameTeamData::isPurchasedBlindTrap);
+    }
+
+    @Override
+    public boolean areMinerTrapEnabled() {
+        return teamDataMap
+                .values()
+                .stream()
+                .anyMatch(GameTeamData::isPurchasedMinerTrap);
     }
 
     @Override

--- a/plugin/src/main/java/io/github/pronze/sba/game/tasks/GameTaskManager.java
+++ b/plugin/src/main/java/io/github/pronze/sba/game/tasks/GameTaskManager.java
@@ -22,6 +22,7 @@ public class GameTaskManager implements IGameTaskManager {
         addTask(GeneratorTask.class);
         addTask(HealPoolTask.class);
         addTask(TrapTask.class);
+        addTask(MinerTrapTask.class);
     }
     @Override
     public void addTask(@NotNull Class<? extends Runnable> task) {

--- a/plugin/src/main/java/io/github/pronze/sba/game/tasks/MinerTrapTask.java
+++ b/plugin/src/main/java/io/github/pronze/sba/game/tasks/MinerTrapTask.java
@@ -59,17 +59,17 @@ public class MinerTrapTask implements Runnable {
 
                                 LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_MESSAGE).replace("%team%", arena.getGame().getTeamOfPlayer(player).getName())
+                                        .get(MessageKeys.TEAM_MINER_TRAP_TRIGGERED_MESSAGE).replace("%team%", arena.getGame().getTeamOfPlayer(player).getName())
                                         .send(PlayerMapper.wrapPlayer(player).as(PlayerWrapper.class));
 
                                 var title = LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_TITLE)
+                                        .get(MessageKeys.TEAM_MINER_TRAP_TRIGGERED_TITLE)
                                         .toString();
 
                                 var subTitle = LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_SUBTITLE)
+                                        .get(MessageKeys.TEAM_MINER_TRAP_TRIGGERED_SUBTITLE)
                                         .toString();
 
                                 team.getConnectedPlayers().forEach(pl -> {

--- a/plugin/src/main/java/io/github/pronze/sba/game/tasks/MinerTrapTask.java
+++ b/plugin/src/main/java/io/github/pronze/sba/game/tasks/MinerTrapTask.java
@@ -16,25 +16,25 @@ import org.screamingsandals.bedwars.Main;
 import org.screamingsandals.bedwars.utils.Sounds;
 import org.screamingsandals.lib.player.PlayerMapper;
 
-public class TrapTask implements Runnable {
+public class MinerTrapTask implements Runnable {
 
     private final Arena arena;
     private final double radius;
 
-    public TrapTask(@NotNull IArena arena) {
+    public MinerTrapTask(@NotNull IArena arena) {
         this.arena = (Arena) arena;
         radius = Math.pow(SBAConfig.getInstance().node("upgrades", "trap-detection-range").getInt(7), 2);
     }
 
     @Override
     public void run() {
-        if (!arena.getStorage().areBlindTrapEnabled()) {
+        if (!arena.getStorage().areMinerTrapEnabled()) {
             return;
         }
 
         arena.getGame().getRunningTeams()
                 .stream()
-                .filter(arena.getStorage()::areBlindTrapEnabled)
+                .filter(arena.getStorage()::areMinerTrapEnabled)
                 .forEach(team -> arena.getGame().getConnectedPlayers()
                         .stream()
                         .filter(player -> !Main.getPlayerGameProfile(player).isSpectator)
@@ -49,9 +49,9 @@ public class TrapTask implements Runnable {
                                     return;
                                 }
 
-                                arena.getStorage().setPurchasedBlindTrap(team, false);
+                                arena.getStorage().setPurchasedMinerTrap(team, false);
                                 player.addPotionEffect(new PotionEffect
-                                        (PotionEffectType.BLINDNESS, 20 * 3, 2));
+                                    (PotionEffectType.SLOW_DIGGING, 20 * 10, 2));
 
                                 if (arena.isPlayerHidden(player)) {
                                     arena.removeHiddenPlayer(player);

--- a/plugin/src/main/java/io/github/pronze/sba/game/tasks/TrapTask.java
+++ b/plugin/src/main/java/io/github/pronze/sba/game/tasks/TrapTask.java
@@ -59,17 +59,17 @@ public class TrapTask implements Runnable {
 
                                 LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_MESSAGE).replace("%team%", arena.getGame().getTeamOfPlayer(player).getName())
+                                        .get(MessageKeys.TEAM_BLIND_TRAP_TRIGGERED_MESSAGE).replace("%team%", arena.getGame().getTeamOfPlayer(player).getName())
                                         .send(PlayerMapper.wrapPlayer(player).as(PlayerWrapper.class));
 
                                 var title = LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_TITLE)
+                                        .get(MessageKeys.TEAM_BLIND_TRAP_TRIGGERED_TITLE)
                                         .toString();
 
                                 var subTitle = LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.TEAM_TRAP_TRIGGERED_SUBTITLE)
+                                        .get(MessageKeys.TEAM_BLIND_TRAP_TRIGGERED_SUBTITLE)
                                         .toString();
 
                                 team.getConnectedPlayers().forEach(pl -> {

--- a/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
+++ b/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
@@ -199,7 +199,7 @@ public class SBAUpgradeStoreInventory extends AbstractStoreInventory {
                             }
                             break;
                         case "blindtrap":
-                            if (gameStorage.areTrapsEnabled(team)) {
+                            if (gameStorage.areBlindTrapEnabled(team)) {
                                 shouldSellStack = false;
                                 LanguageService
                                         .getInstance()
@@ -211,9 +211,28 @@ public class SBAUpgradeStoreInventory extends AbstractStoreInventory {
                                         .get(MessageKeys.BLINDNESS_TRAP_PURCHASED_TITLE)
                                         .toString();
 
-                                gameStorage.setPurchasedTrap(team, true);
+                                gameStorage.setPurchasedBlindTrap(team, true);
                                 team.getConnectedPlayers().forEach(pl ->
                                         SBAUtil.sendTitle(PlayerMapper.wrapPlayer(pl), blindnessTrapTitle, "", 20, 40, 20));
+                            }
+                            break;
+
+                        case "minertrap":
+                            if (gameStorage.areMinerTrapEnabled(team)) {
+                                shouldSellStack = false;
+                                LanguageService
+                                        .getInstance()
+                                        .get(MessageKeys.WAIT_FOR_TRAP)
+                                        .send(wrappedPlayer);
+                            } else {
+                                final var minerTrapTitle = LanguageService
+                                        .getInstance()
+                                        .get(MessageKeys.BLINDNESS_TRAP_PURCHASED_TITLE)
+                                        .toString();
+
+                                gameStorage.setPurchasedMinerTrap(team, true);
+                                team.getConnectedPlayers().forEach(pl ->
+                                        SBAUtil.sendTitle(PlayerMapper.wrapPlayer(pl), minerTrapTitle, "", 20, 40, 20));
                             }
                             break;
 

--- a/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
+++ b/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
@@ -228,7 +228,7 @@ public class SBAUpgradeStoreInventory extends AbstractStoreInventory {
                             } else {
                                 final var minerTrapTitle = LanguageService
                                         .getInstance()
-                                        .get(MessageKeys.BLINDNESS_TRAP_PURCHASED_TITLE)
+                                        .get(MessageKeys.MINER_TRAP_PURCHASED_TITLE)
                                         .toString();
 
                                 gameStorage.setPurchasedMinerTrap(team, true);

--- a/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
+++ b/plugin/src/main/java/io/github/pronze/sba/inventories/SBAUpgradeStoreInventory.java
@@ -48,6 +48,7 @@ public class SBAUpgradeStoreInventory extends AbstractStoreInventory {
             "protection",
             "efficiency",
             "blindtrap",
+            "minertrap",
             "healpool",
             "dragon"
     );

--- a/plugin/src/main/resources/languages/language_en.yml
+++ b/plugin/src/main/resources/languages/language_en.yml
@@ -32,8 +32,12 @@ error-occured: "<red><bold>AN ERROR HAS OCCURRED</bold>"
 greatest-enchantment: "<red><bold>You Already have the greatest enchantment</bold>"
 generator-upgrade: "%MatName%<yellow> generator has been upgraded to <red>%tier%"
 shout-format: "<gold>[SHOUT] %color%[%team%]<reset> %player%<gray>: <reset>%message%"
-trap-triggered:
+blind-trap-triggered:
   message: "<yellow>You have been blinded by %team% team!"
+  title: "<red>Trap Triggered!"
+  sub-title: "<yellow>Someone has entered your base!"
+miner-trap-triggered:
+  message: "<yellow>You have been slowed by %team% team!"
   title: "<red>Trap Triggered!"
   sub-title: "<yellow>Someone has entered your base!"
 blindness-trap-purchased-title: "<gold>Blindness Trap has been purchased!"

--- a/plugin/src/main/resources/languages/language_en.yml
+++ b/plugin/src/main/resources/languages/language_en.yml
@@ -41,6 +41,7 @@ miner-trap-triggered:
   title: "<red>Trap Triggered!"
   sub-title: "<yellow>Someone has entered your base!"
 blindness-trap-purchased-title: "<gold>Blindness Trap has been purchased!"
+miner-trap-purchased-title: "<gold>Mining Fatigue Trap has been purchased!"
 purchase-heal-pool: "<aqua>Heal Pool has been purchased by: %player%"
 respawn-title: "<red>YOU DIED!"
 respawn-message: "<yellow>You will respawn in <red>%time% <yellow>seconds"

--- a/plugin/src/main/resources/shops/upgradeShop.yml
+++ b/plugin/src/main/resources/shops/upgradeShop.yml
@@ -14,17 +14,24 @@ data:
     column: 3
     properties: efficiency
 
-  - price: 4
-    price-type: iron
-    stack:
-      ==: org.bukkit.inventory.ItemStack
-      v: 1519
-      type: FURNACE
-      amount: 1
-      meta:
-        ==: ItemMeta
-        meta-type: UNSPECIFIC
-        display-name: "Forge Upgrade, Unconfigured"
+  - price: 8
+      price-type: diamond
+      upgrade:
+        entities:
+          - type: spawner
+            spawner-type: iron
+            add-levels: 0.5
+            shop-name: "Iron upgrade of the team %team%"
+            notify-team: true
+      stack:
+        ==: org.bukkit.inventory.ItemStack
+        v: 1519
+        type: FURNANCE
+        amount: 1
+        meta:
+          ==: ItemMeta
+          meta-type: UNSPECIFIC
+          display-name: "Iron upgrade of the team %team%"
 
   - stack: "BEACON;1;§bHeal Pool;§7Triggers a pool around the base that heals you!"
     column: 5
@@ -32,7 +39,7 @@ data:
     properties: healpool
     price: 8 of diamond
 
-  - stack: "DRAGON_EGG;1;Ender Dragon;Unconfigured"
+  - stack: "DRAGON_EGG;1;Ender Dragon;Get A Bonus Dragon when Dragons get summoned!"
     column: 6
     row: 1
 
@@ -49,41 +56,15 @@ data:
             - "§7Get informed when an enemy enters a 7 block radius of your base"
             - "§7Blind the foe and gain an upper advantage!"
 
-      - price: 1 of gold
-        properties:
-          - name: "Trap"
-            data:
-              - sound: ENTITY_SHEEP_AMBIENT
-              - effect:
-                  ==: org.bukkit.potion.PotionEffect
-                  effect: 15
-                  amplifier: 2
-                  duration: 100
-                  ambient: true
-                  has-particles: true
-                  has-icon: true
-              - effect:
-                  ==: org.bukkit.potion.PotionEffect
-                  effect: 18
-                  amplifier: 2
-                  duration: 100
-                  ambient: true
-                  has-particles: true
-                  has-icon: true
-              - effect:
-                  ==: org.bukkit.potion.PotionEffect
-                  effect: 2
-                  amplifier: 2
-                  duration: 100
-                  ambient: true
-                  has-particles: true
-                  has-icon: true
+      - price: 2 of diamond
+        skip: 1
+        properties: minertrap
         stack:
           type: STRING
-          display-name: "Trap"
+          display-name: "§bMining Fatigue trap"
           lore:
-            - "Get informed if an enemy steps on your trap"
-            - "and your enemy won't be able to move properly."
+            - "§7Get informed when an enemy enters a 7 block radius of your base"
+            - "§7Slow Down their mining and gain an advantage!"
 
   - stack: "GRAY_STAINED_GLASS_PANE;1;*****"
     row: 2


### PR DESCRIPTION
Adds a Second trap to the SBA Upgrade Shop. The Mining Fatigue trap, it hits enemies with Mining Fatigue for 10 seconds, giving the defending team an advantage.

Notes:
Has Not Been Fully Tested, however all signs point to it working.